### PR TITLE
Add Schema Validation with TypeScript (Closing in favor of #6)

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,111 @@
+/**
+ * TypeScript type definitions for structured data schemas
+ * 
+ * This file contains type definitions for the structured data (JSON-LD)
+ * schemas used in the application. These types ensure type safety and
+ * provide better IDE support for schema development.
+ */
+
+/**
+ * Base schema interface with common properties
+ */
+export interface BaseSchema {
+  '@context': 'https://schema.org';
+  '@type': string;
+  name: string;
+  url?: string;
+  description?: string;
+}
+
+/**
+ * Contact point information for organizations
+ */
+export interface ContactPoint {
+  '@type': 'ContactPoint';
+  telephone: string;
+  contactType: string;
+  availableLanguage?: string;
+}
+
+/**
+ * Organization schema interface
+ */
+export interface OrganizationSchema extends BaseSchema {
+  '@type': 'Organization';
+  logo: string;
+  contactPoint?: ContactPoint;
+  sameAs?: string[];
+}
+
+/**
+ * Brand information for products
+ */
+export interface Brand {
+  '@type': 'Brand';
+  name: string;
+}
+
+/**
+ * Offer information for products
+ */
+export interface Offer {
+  '@type': 'Offer';
+  priceCurrency: string;
+  availability: string;
+  seller: {
+    '@type': 'Organization';
+    name: string;
+  };
+}
+
+/**
+ * Aggregate rating information
+ */
+export interface AggregateRating {
+  '@type': 'AggregateRating';
+  ratingValue: string;
+  reviewCount: string;
+}
+
+/**
+ * Product schema interface
+ */
+export interface ProductSchema extends BaseSchema {
+  '@type': 'Product';
+  brand: Brand;
+  category?: string;
+  offers: Offer;
+  aggregateRating?: AggregateRating;
+}
+
+/**
+ * Website schema interface
+ */
+export interface WebsiteSchema extends BaseSchema {
+  '@type': 'WebSite';
+}
+
+/**
+ * Valid availability values for product offers
+ */
+export const VALID_AVAILABILITY_STATES = [
+  'https://schema.org/InStock',
+  'https://schema.org/OutOfStock',
+  'https://schema.org/PreOrder',
+  'https://schema.org/Discontinued'
+] as const;
+
+/**
+ * Valid currency codes
+ */
+export const VALID_CURRENCIES = ['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD'] as const;
+
+/**
+ * Type for valid availability states
+ */
+export type AvailabilityState = typeof VALID_AVAILABILITY_STATES[number];
+
+/**
+ * Type for valid currency codes
+ */
+export type CurrencyCode = typeof VALID_CURRENCIES[number];

--- a/src/utils/validators.test.ts
+++ b/src/utils/validators.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { isValidUrl, isValidCurrency, isValidAvailability, isValidRating, isValidReviewCount } from './validators';
+
+describe('Schema Validators', () => {
+  describe('isValidUrl', () => {
+    it('validates correct URLs', () => {
+      expect(isValidUrl('https://choji.store')).toBe(true);
+      expect(isValidUrl('http://example.com')).toBe(true);
+      expect(isValidUrl('https://sub.domain.com/path?query=value')).toBe(true);
+    });
+
+    it('rejects invalid URLs', () => {
+      expect(isValidUrl('not-a-url')).toBe(false);
+      expect(isValidUrl('http://')).toBe(false);
+      expect(isValidUrl('ftp://invalid')).toBe(false);
+    });
+  });
+
+  describe('isValidCurrency', () => {
+    it('accepts valid currency codes', () => {
+      expect(isValidCurrency('USD')).toBe(true);
+      expect(isValidCurrency('EUR')).toBe(true);
+      expect(isValidCurrency('GBP')).toBe(true);
+    });
+
+    it('rejects invalid currency codes', () => {
+      expect(isValidCurrency('INVALID')).toBe(false);
+      expect(isValidCurrency('US')).toBe(false);
+      expect(isValidCurrency('')).toBe(false);
+    });
+  });
+
+  describe('isValidAvailability', () => {
+    it('accepts valid availability states', () => {
+      expect(isValidAvailability('https://schema.org/InStock')).toBe(true);
+      expect(isValidAvailability('https://schema.org/OutOfStock')).toBe(true);
+      expect(isValidAvailability('https://schema.org/PreOrder')).toBe(true);
+    });
+
+    it('rejects invalid availability states', () => {
+      expect(isValidAvailability('InStock')).toBe(false);
+      expect(isValidAvailability('')).toBe(false);
+      expect(isValidAvailability('https://schema.org/Invalid')).toBe(false);
+    });
+  });
+
+  describe('isValidRating', () => {
+    it('accepts valid rating values', () => {
+      expect(isValidRating('0')).toBe(true);
+      expect(isValidRating('3.5')).toBe(true);
+      expect(isValidRating('5')).toBe(true);
+    });
+
+    it('rejects invalid rating values', () => {
+      expect(isValidRating('-1')).toBe(false);
+      expect(isValidRating('6')).toBe(false);
+      expect(isValidRating('not a number')).toBe(false);
+    });
+  });
+
+  describe('isValidReviewCount', () => {
+    it('accepts valid review counts', () => {
+      expect(isValidReviewCount('0')).toBe(true);
+      expect(isValidReviewCount('100')).toBe(true);
+      expect(isValidReviewCount('1000')).toBe(true);
+    });
+
+    it('rejects invalid review counts', () => {
+      expect(isValidReviewCount('-1')).toBe(false);
+      expect(isValidReviewCount('3.5')).toBe(false);
+      expect(isValidReviewCount('not a number')).toBe(false);
+    });
+  });
+});

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,57 @@
+/**
+ * Validation functions for structured data schemas
+ */
+
+import { VALID_AVAILABILITY_STATES, VALID_CURRENCIES, type AvailabilityState, type CurrencyCode } from './types';
+
+/**
+ * Validate a URL string
+ * @param url The URL to validate
+ * @returns true if valid, false otherwise
+ */
+export const isValidUrl = (url: string): boolean => {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Validate a currency code
+ * @param currency The currency code to validate
+ * @returns true if valid, false otherwise
+ */
+export const isValidCurrency = (currency: string): currency is CurrencyCode => {
+  return VALID_CURRENCIES.includes(currency as CurrencyCode);
+};
+
+/**
+ * Validate an availability state
+ * @param state The availability state to validate
+ * @returns true if valid, false otherwise
+ */
+export const isValidAvailability = (state: string): state is AvailabilityState => {
+  return VALID_AVAILABILITY_STATES.includes(state as AvailabilityState);
+};
+
+/**
+ * Validate a rating value
+ * @param rating The rating value to validate
+ * @returns true if valid, false otherwise
+ */
+export const isValidRating = (rating: string): boolean => {
+  const numericRating = parseFloat(rating);
+  return !isNaN(numericRating) && numericRating >= 0 && numericRating <= 5;
+};
+
+/**
+ * Validate a review count
+ * @param count The review count to validate
+ * @returns true if valid, false otherwise
+ */
+export const isValidReviewCount = (count: string): boolean => {
+  const numericCount = parseInt(count, 10);
+  return !isNaN(numericCount) && numericCount >= 0;
+};


### PR DESCRIPTION
Closing this PR in favor of #6 which provides a more comprehensive implementation including test coverage.